### PR TITLE
docs(guide/templates): add missing closing `<script>` tag

### DIFF
--- a/docs/content/guide/templates.ngdoc
+++ b/docs/content/guide/templates.ngdoc
@@ -30,7 +30,7 @@ curly-brace {@link expression expression} bindings:
           string expression 'buttonText'
           wrapped in "{{ }}" markup -->
    <button ng-click="changeFoo()">{{buttonText}}</button>
-   <script src="angular.js">
+   <script src="angular.js"></script>
  </body>
 </html>
 ```


### PR DESCRIPTION
Closes #15961

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**



**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**



**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

